### PR TITLE
add submenu to packages for consistency

### DIFF
--- a/menus/find-and-replace.cson
+++ b/menus/find-and-replace.cson
@@ -1,24 +1,53 @@
 'menu': [
-  'label': 'Find'
-  'submenu': [
-    { 'label': 'Find in Buffer', 'command': 'find-and-replace:show'}
-    { 'label': 'Replace in Buffer', 'command': 'find-and-replace:show-replace'}
-    { 'label': 'Select Next', 'command': 'find-and-replace:select-next'}
-    { 'label': 'Select All', 'command': 'find-and-replace:select-all'}
-    { 'label': 'Toggle Find in Buffer', 'command': 'find-and-replace:toggle'}
-    { 'type': 'separator' }
-    { 'label': 'Find in Project', 'command': 'project-find:show'}
-    { 'label': 'Toggle Find in Project', 'command': 'project-find:toggle'}
-    { 'type': 'separator' }
-    { 'label': 'Find All', 'command': 'find-and-replace:find-all'}
-    { 'label': 'Find Next', 'command': 'find-and-replace:find-next'}
-    { 'label': 'Find Previous', 'command': 'find-and-replace:find-previous'}
-    { 'label': 'Replace Next', 'command': 'find-and-replace:replace-next'}
-    { 'label': 'Replace All', 'command': 'find-and-replace:replace-all'}
-    { 'type': 'separator' }
-    { 'label': 'Clear History', 'command': 'find-and-replace:clear-history'}
-    { 'type': 'separator' }
-  ]
+  {
+    'label': 'Packages'
+    'submenu': [
+      'label': 'Find and Replace'
+      'submenu': [
+        { 'label': 'Find in Buffer', 'command': 'find-and-replace:show'}
+        { 'label': 'Replace in Buffer', 'command': 'find-and-replace:show-replace'}
+        { 'label': 'Select Next', 'command': 'find-and-replace:select-next'}
+        { 'label': 'Select All', 'command': 'find-and-replace:select-all'}
+        { 'label': 'Toggle Find in Buffer', 'command': 'find-and-replace:toggle'}
+        { 'type': 'separator' }
+        { 'label': 'Find in Project', 'command': 'project-find:show'}
+        { 'label': 'Toggle Find in Project', 'command': 'project-find:toggle'}
+        { 'type': 'separator' }
+        { 'label': 'Find All', 'command': 'find-and-replace:find-all'}
+        { 'label': 'Find Next', 'command': 'find-and-replace:find-next'}
+        { 'label': 'Find Previous', 'command': 'find-and-replace:find-previous'}
+        { 'label': 'Replace Next', 'command': 'find-and-replace:replace-next'}
+        { 'label': 'Replace All', 'command': 'find-and-replace:replace-all'}
+        { 'type': 'separator' }
+        { 'label': 'Clear History', 'command': 'find-and-replace:clear-history'}
+        { 'type': 'separator' }
+      ]
+    ]
+  }
+  
+  {
+    'label': 'Find'
+    'before': ['Packages']
+    'submenu': [
+      { 'label': 'Find in Buffer', 'command': 'find-and-replace:show'}
+      { 'label': 'Replace in Buffer', 'command': 'find-and-replace:show-replace'}
+      { 'label': 'Select Next', 'command': 'find-and-replace:select-next'}
+      { 'label': 'Select All', 'command': 'find-and-replace:select-all'}
+      { 'label': 'Toggle Find in Buffer', 'command': 'find-and-replace:toggle'}
+      { 'type': 'separator' }
+      { 'label': 'Find in Project', 'command': 'project-find:show'}
+      { 'label': 'Toggle Find in Project', 'command': 'project-find:toggle'}
+      { 'type': 'separator' }
+      { 'label': 'Find All', 'command': 'find-and-replace:find-all'}
+      { 'label': 'Find Next', 'command': 'find-and-replace:find-next'}
+      { 'label': 'Find Previous', 'command': 'find-and-replace:find-previous'}
+      { 'label': 'Replace Next', 'command': 'find-and-replace:replace-next'}
+      { 'label': 'Replace All', 'command': 'find-and-replace:replace-all'}
+      { 'type': 'separator' }
+      { 'label': 'Clear History', 'command': 'find-and-replace:clear-history'}
+      { 'type': 'separator' }
+    ]
+  }
 ]
 
 'context-menu':


### PR DESCRIPTION
This clones the find and replace menu into the packages menu to be more consistent with other packages.
This is also preparing for removing these lines by making the placement of the menu relative to the packages menu.

[`pulsar/menus/linux.cson#L174-L177`](https://github.com/pulsar-edit/pulsar/blob/7de77d275fe276cd65e98b73ea973ef94844f184/menus/linux.cson#L174-L177)
[`pulsar/menus/darwin.cson#L191-L194`](https://github.com/pulsar-edit/pulsar/blob/7de77d275fe276cd65e98b73ea973ef94844f184/menus/darwin.cson#L191-L194)
[`pulsar/menus/win32.cson#L173-L176`](https://github.com/pulsar-edit/pulsar/blob/7de77d275fe276cd65e98b73ea973ef94844f184/menus/win32.cson#L173-L176)